### PR TITLE
Fail snapshot diffs on test, update snapshots from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Containing `StateProcessorValue(10)` and `StateProcessorValue(20)` respectively
 
 Often on your tests one of your expectations will stop complying with the currently saved snapshot. This means that either the cod is not working as expected or the new output is the correct one.
 
-When running your tests locally, you will be prompted to update the snapshot as soon as one of those expectations fails. Choosing `no` you generate failed results and choosing yes you will have a good result with your updated snapshot.
+When running your tests locally, you can run the following `sbt test -DupdateSnapshots=true`
  
 ### Custom Serializers
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Containing `StateProcessorValue(10)` and `StateProcessorValue(20)` respectively
 
 Often on your tests one of your expectations will stop complying with the currently saved snapshot. This means that either the cod is not working as expected or the new output is the correct one.
 
-When running your tests locally, you can run the following `sbt test -DupdateSnapshots=true`
+When running your tests locally, you can run the following `updateSnapshots=true sbt test`
  
 ### Custom Serializers
 


### PR DESCRIPTION
Ref: https://github.com/commodityvectors/scalatest-snapshot-matchers/issues/7

- Fail on test, makes it CI compatible if someone pushes without testing
- Explicitly update snapshots on command line `updateSnapshots=true sbt test`
- No hanging in IntelliJ when there is a diff

This is similar behaviour to jest: https://jestjs.io/docs/en/snapshot-testing 

With command: `sbt test`
```
[info] Done compiling.
[info] HelloWorldSpec:
[info] - should match HelloWorld *** FAILED ***
[info]   Text Did not match:
[info]   --- Original Snapshot
[info]   +++ New Snapshot
[info]   @@ -1,1 +1,1 @@
[info]   -"Hello, World!"
[info]   +"Hello, World!!"
[info]   
[info]   End Diff; (HelloWorldSpec.scala:12)
[info] - should return say Hello, World!
[info] Run completed in 326 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
```

With command: `updateSnapshots=true sbt test`
```
 ### Updating Snapshots: should match HelloWorld ###
[info] HelloWorldSpec:
[info] - should match HelloWorld
[info] - should return say Hello, World!
[info] Run completed in 315 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 2 s, completed 13-Sep-2018 21:37:38
```